### PR TITLE
fix `get_edge_ids()` issue

### DIFF
--- a/R/ego_network.r
+++ b/R/ego_network.r
@@ -66,7 +66,7 @@ ego_semnet <- function(g, vertex_names, depth=1, only_filter_vertices=T, weight_
     i = unique(c(ego$x, ego$y))
     g = igraph::delete.vertices(g, which(!1:igraph::vcount(g) %in% i))
   } else {
-    i = igraph::get.edge.ids(g, vp=rbind(ego$x, ego$y))
+    i = igraph::get_edge_ids(g, vp=c(rbind(ego$x, ego$y)))
     g = igraph::delete_edges(g, which(!1:igraph::ecount(g) %in% i))
     g = igraph::delete_vertices(g, which(igraph::degree(g) == 0))
   }


### PR DESCRIPTION
igraph is changing the way `get_edge_ids()` works. (see. https://github.com/igraph/rigraph/pull/1663). In the future, the function will also accept nx2 matrices and data frames besides a vector. Currently 2xn matrices work by accident which means 2x2 matrices are hard to interpret in the transition phase (is an edge a row or a column?). This PR fixes this for the package to remove possible ambiguous cases. 